### PR TITLE
Refatoração e Migração para o Google Places SDK 4.0.0 Nativo

### DIFF
--- a/.idea/AndroidProjectSystem.xml
+++ b/.idea/AndroidProjectSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidProjectSystem">
+    <option name="providerId" value="com.android.tools.idea.GradleProjectSystem" />
+  </component>
+</project>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="app">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,6 +4,14 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2026-03-31T22:38:58.661031Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Android\.android\.android\avd\Pixel.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/.idea/migrations.xml
+++ b/.idea/migrations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectMigrations">
+    <option name="MigrateToGradleLocalJavaHome">
+      <set>
+        <option value="$PROJECT_DIR$" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="NullableNotNullManager">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="NullableNotNullManager">
     <option name="myDefaultNullable" value="android.support.annotation.Nullable" />
     <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />
@@ -39,7 +40,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="ms-11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -3,6 +3,14 @@
   <component name="RunConfigurationProducerService">
     <option name="ignoredProducers">
       <set>
+        <option value="com.intellij.execution.junit.AbstractAllInDirectoryConfigurationProducer" />
+        <option value="com.intellij.execution.junit.AllInPackageConfigurationProducer" />
+        <option value="com.intellij.execution.junit.PatternConfigurationProducer" />
+        <option value="com.intellij.execution.junit.TestInClassConfigurationProducer" />
+        <option value="com.intellij.execution.junit.UniqueIdConfigurationProducer" />
+        <option value="com.intellij.execution.junit.testDiscovery.JUnitTestDiscoveryConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinJUnitRunConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinPatternConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.AllInPackageGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestClassGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestMethodGradleConfigurationProducer" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId 'teste.lucasvegi.pokemongooffline'
-        minSdkVersion 17
+        minSdkVersion 24
         targetSdkVersion 28
         versionCode 1
         versionName '0.4'
@@ -31,6 +31,6 @@ dependencies {
     implementation 'com.google.android.gms:play-services-maps:17.0.0'
     def multidex_version = "2.0.1"
     implementation "androidx.multidex:multidex:$multidex_version"
-    implementation 'com.google.android.libraries.places:places:2.4.0'
+    implementation 'com.google.android.libraries.places:places:4.0.0'
     implementation 'com.android.volley:volley:1.2.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,4 +32,5 @@ dependencies {
     def multidex_version = "2.0.1"
     implementation "androidx.multidex:multidex:$multidex_version"
     implementation 'com.google.android.libraries.places:places:2.4.0'
+    implementation 'com.android.volley:volley:1.2.1'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -116,7 +116,7 @@
         <!-- CHAVE API KEY -->
         <meta-data
             android:name="com.google.android.maps.v2.API_KEY"
-            android:value="AIzaSyD32K88SnMpmPlsQngbAaL566MOePzWWQY" />
+            android:value="AIzaSyBfQXz5ilMcVL-CwPRkNsbjqmNQjBHokB4" />
         <!-- com chave de debug -->
 
     </application>

--- a/app/src/main/java/teste/lucasvegi/pokemongooffline/Controller/MapActivity.java
+++ b/app/src/main/java/teste/lucasvegi/pokemongooffline/Controller/MapActivity.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import teste.lucasvegi.pokemongooffline.Model.AoCarregarPokestopsListener;
 import teste.lucasvegi.pokemongooffline.Model.Aparecimento;
 import teste.lucasvegi.pokemongooffline.Model.ControladoraFachadaSingleton;
 import teste.lucasvegi.pokemongooffline.Model.InteracaoPokestop;
@@ -379,6 +380,9 @@ public class MapActivity extends FragmentActivity implements LocationListener, G
             Locpkstp.setLatitude(marker.getPosition().latitude);
             Locpkstp.setLongitude(marker.getPosition().longitude);
             double DistPkStop = getDistanciaPkStop(eu, Locpkstp);
+
+            Log.d("POKESTOP_DISTANCIA", "Distância até " + marker.getTitle() + ": " + DistPkStop + " metros");
+
             double distMin = distanciaMinimaParaBatalhar; //enquanto nao decidimos uma distancia apropriada deixar a mesma da batalha
             if (DistPkStop > distMin) {
                 DecimalFormat df = new DecimalFormat("0.##");
@@ -540,35 +544,32 @@ public class MapActivity extends FragmentActivity implements LocationListener, G
     }
 
     public void plotarPokestops() {
-        List<Pokestop> list = ControladoraFachadaSingleton.getInstance().getPokestops(eu.getPosition().latitude, eu.getPosition().longitude);
-        for (int i = 0; i < list.size(); i++) {
-            Pokestop p = list.get(i);
-            Location pkstp = new Location(provider);
-            pkstp.setLongitude(p.getlongi());
-            pkstp.setLatitude(p.getlat());
-            Marker pokestopMarker;
+        // Pegamos a posição atual do marcador do jogador
+        if (eu != null) {
+            LatLng posicaoUsuario = eu.getPosition();
 
-            double distancia = getDistanciaPkStop(eu, pkstp);
-            double distanciaMin = distanciaMinimaParaBatalhar;
+            ControladoraFachadaSingleton.getInstance().getPokestops(posicaoUsuario, new AoCarregarPokestopsListener() {
+                @Override
+                public void onPokestopsCarregados(List<Pokestop> lista) {
+                    for (Pokestop p : lista) {
+                        Location pkstpLoc = new Location("");
+                        pkstpLoc.setLatitude(p.getlat());
+                        pkstpLoc.setLongitude(p.getlongi());
 
-            if (p.getUltimoAcesso() != null) {
-                Date TempoAtual = Calendar.getInstance().getTime();
-                double diff = TempoAtual.getTime() - p.getUltimoAcesso().getTime();
-                double diffMinuto = diff / (1000);
-                if (diffMinuto > 300) {
-                    p.setDisponivel(true);
+                        double distancia = getDistanciaPkStop(eu, pkstpLoc);
+                        boolean noAlcance = distancia < distanciaMinimaParaBatalhar;
+
+                        Marker pokestopMarker = map.addMarker(p.getMarkerOptions(noAlcance));
+                        pokestopMarker.setTag("pokestop");
+                        pokestopMap.put(pokestopMarker, p);
+                    }
                 }
-            }
-            pokestopMarker = map.addMarker(p.getMarkerOptions(distancia < distanciaMin));
-            pokestopMarker.setTag("pokestop");
-            pokestopMap.put(pokestopMarker, p);
-
+            });
         }
-
     }
 
+
     public void plotarMarcadores() {
-        //Plota Marcadores
         try {
             Aparecimento [] apVet = ControladoraFachadaSingleton.getInstance().getAparecimentos();
 

--- a/app/src/main/java/teste/lucasvegi/pokemongooffline/Controller/SplashActivity.java
+++ b/app/src/main/java/teste/lucasvegi/pokemongooffline/Controller/SplashActivity.java
@@ -1,5 +1,8 @@
 package teste.lucasvegi.pokemongooffline.Controller;
 
+import com.google.android.libraries.places.api.Places;
+import com.google.android.libraries.places.api.net.PlacesClient;
+
 import android.app.Activity;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
@@ -32,6 +35,10 @@ public class SplashActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_splash);
+
+        if (!Places.isInitialized()) {
+            Places.initialize(getApplicationContext(), "AIzaSyDATgN7KkYfXdALYKaxzvez087PHB6Xtm4");
+        }
 
         configuraViewInicio();
         if (ActivityCompat.checkSelfPermission(this, android.Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(this, android.Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED)

--- a/app/src/main/java/teste/lucasvegi/pokemongooffline/Model/AoCarregarPokestopsListener.java
+++ b/app/src/main/java/teste/lucasvegi/pokemongooffline/Model/AoCarregarPokestopsListener.java
@@ -1,0 +1,6 @@
+package teste.lucasvegi.pokemongooffline.Model;
+import java.util.List;
+
+public interface AoCarregarPokestopsListener {
+    void onPokestopsCarregados(List<Pokestop> lista);
+}

--- a/app/src/main/java/teste/lucasvegi/pokemongooffline/Model/ControladoraFachadaSingleton.java
+++ b/app/src/main/java/teste/lucasvegi/pokemongooffline/Model/ControladoraFachadaSingleton.java
@@ -1,18 +1,25 @@
 package teste.lucasvegi.pokemongooffline.Model;
 
+import android.Manifest;
 import android.content.ContentValues;
+import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.util.Log;
 import android.widget.Toast;
 
+import androidx.core.app.ActivityCompat;
+
 import com.google.android.gms.common.api.ApiException;
+import com.google.android.gms.maps.model.LatLng;
 import com.google.android.libraries.places.api.Places;
 import com.google.android.libraries.places.api.model.PhotoMetadata;
 import com.google.android.libraries.places.api.model.Place;
 import com.google.android.libraries.places.api.net.FetchPhotoRequest;
 import com.google.android.libraries.places.api.net.FetchPlaceRequest;
 import com.google.android.libraries.places.api.net.PlacesClient;
+import com.google.android.libraries.places.api.net.FindCurrentPlaceRequest;
+import com.google.android.libraries.places.api.model.PlaceLikelihood;
 import com.google.maps.model.PlacesSearchResult;
 
 import java.util.ArrayList;
@@ -24,6 +31,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import teste.lucasvegi.pokemongooffline.Util.BancoDadosSingleton;
 import teste.lucasvegi.pokemongooffline.Util.MyApp;
@@ -323,110 +331,91 @@ public final class ControladoraFachadaSingleton {
         return pkmn;
     }
 
-    public List<Pokestop> getPokestops(double latitude, double longitude){
-        List<Pokestop> list = new ArrayList<Pokestop>();
-
-        PlacesSearchResult[] placesSearchResults = NearbySearch.run(new com.google.maps.model.LatLng(latitude, longitude)).results;
-        if(placesSearchResults != null) {
-            for (int i = 0; placesSearchResults != null && i < placesSearchResults.length / 2; i++) {
-                double lat = placesSearchResults[i].geometry.location.lat;
-                double lng = placesSearchResults[i].geometry.location.lng;
-
-                Pokestop pokestop = new Pokestop(placesSearchResults[i].placeId, placesSearchResults[i].name);
-                pokestop.setlat(lat);
-                pokestop.setlong(lng);
-                if (placesSearchResults[i].types != null && placesSearchResults[i].types.length > 0)
-                    pokestop.setDescri(placesSearchResults[i].types[0]);
-
-                //TODO : setar imagem do pokestop dentro da classe do pokestop
-                if (placesSearchResults[i].photos != null && placesSearchResults[i].photos.length > 0)
-                    getPlaceImage(pokestop);
-
-                Cursor cPokestop = BancoDadosSingleton.getInstance().buscar("pokestop pkstp",
-                        new String[]{"pkstp.disponivel disponivel"},
-                        "pkstp.idPokestop = '" + pokestop.getID() + "'",
-                        "");
-                if (cPokestop.getCount() > 0) {
-                    while (cPokestop.moveToNext()) {
-                        int coluna = cPokestop.getColumnIndex("disponivel");
-                        if (cPokestop.getInt(coluna) == 0) {
-                            pokestop.setDisponivel(false);
-                        } else
-                            pokestop.setDisponivel(true);
-                    }
-                }
-                else{
-                    ContentValues valores = new ContentValues();
-                    valores.put("idPokestop",pokestop.getID());
-                    valores.put("latitude",pokestop.getlat());
-                    valores.put("longitude",pokestop.getlongi());
-                    valores.put("disponivel",true);
-
-                    long id = BancoDadosSingleton.getInstance().inserir("Pokestop",valores);
-                    Log.d("POKEACTIVITY","CADASTROU NO BD OU ATUALIZOU COM ID = "+id);
-                }
-
-                InteracaoPokestop it = getUltimaInteracao(pokestop);
-                //atualizar se eh possivel interagir em questao de tempo
-                if (it.getUltimoAcesso() != null) {
-                    Date TempoAtual = Calendar.getInstance().getTime();
-                    double diff = TempoAtual.getTime() - it.getUltimoAcesso().getTime();
-                    int diffSec = (int) diff / (1000);
-                    if (diffSec> 300) {
-                        pokestop.setDisponivel(true);
-                    }
-                    else
-                        pokestop.setDisponivel(false);
-                }
-
-                list.add(pokestop);
-
-            }
+    private void verificarFim(AtomicInteger cont, int total, List<Pokestop> lista, AoCarregarPokestopsListener listener) {
+        if (cont.incrementAndGet() == total) {
+            listener.onPokestopsCarregados(lista);
         }
-        return list;
     }
 
-    //Recuperar imagem do local usando sdk places
-    private void getPlaceImage(Pokestop pokestop) {
-        //calcula a distancia e ve se eh valido interagir
-        // Inicializa o SDK
-        Places.initialize(MyApp.getAppContext(), "AIzaSyD_82FN8rMIJzMrZyx1l7xZbpW1SYN5pdU");
-        // Instancia Placesclient
-        PlacesClient placesClient = Places.createClient(MyApp.getAppContext());
+    public void getPokestops(LatLng localizacaoUsuario, final AoCarregarPokestopsListener listener) {
+        final List<Pokestop> listaFinal = new ArrayList<>();
 
-        List<Place.Field> fields = Arrays.asList(Place.Field.PHOTO_METADATAS);
+        // Chama o nearby search para obter os lugares
+        NearbySearch.run(localizacaoUsuario).addOnSuccessListener(response -> {
+            List<Place> places = response.getPlaces();
 
-        FetchPlaceRequest placeRequest = FetchPlaceRequest.builder(pokestop.getID(), fields).build();
+            if (places.isEmpty()) {
+                listener.onPokestopsCarregados(listaFinal);
+                return;
+            }
 
-        // faz request pra imagem, depois ve um tamanho bom pra padronizar as imagens
-        placesClient.fetchPlace(placeRequest).addOnSuccessListener((response) -> {
-            Place place = response.getPlace();
-            // Get the photo metadata.
-            List<PhotoMetadata> list = place.getPhotoMetadatas();
-            if (list != null && list.size() > 0) {
-                PhotoMetadata photoMetadata = place.getPhotoMetadatas().get(0);
-                // Get the attribution text.
-                String attributions = photoMetadata.getAttributions();
-                // Create a FetchPhotoRequest.
-                FetchPhotoRequest photoRequest = FetchPhotoRequest.builder(photoMetadata)
-                        .setMaxWidth(500) // Optional.
-                        .setMaxHeight(300) // Optional.
-                        .build();
-                placesClient.fetchPhoto(photoRequest).addOnSuccessListener((fetchPhotoResponse) -> {
-                    Bitmap bitmap = fetchPhotoResponse.getBitmap();
-                    // PASSAR A IMAGEM PRO POKESTOP
-                    pokestop.setFoto(bitmap);
-                }).addOnFailureListener((exception) -> {
-                    if (exception instanceof ApiException) {
-                        ApiException apiException = (ApiException) exception;
-                        int statusCode = apiException.getStatusCode();
-                        // Erro
-                        Log.e("TAG", "Lugar nao encontrado: " + exception.getMessage());
+            final int total = places.size();
+            final AtomicInteger processados = new AtomicInteger(0);
+
+            for (Place place : places) {
+                Pokestop pokestop = new Pokestop(place.getId(), place.getName());
+                if (place.getLatLng() != null) {
+                    pokestop.setlat(place.getLatLng().latitude);
+                    pokestop.setlong(place.getLatLng().longitude);
+                }
+
+                // Chama a lógica de banco de dados
+                processarBancoDeDados(pokestop);
+
+                // Busca a imagem dos lugares usando o metodo especifico
+                getPlaceImage(pokestop, place.getPhotoMetadatas(), () -> {
+                    listaFinal.add(pokestop);
+                    // Quando terminarem (fotos inclusas ou falhas), avisa o listener
+                    if (processados.incrementAndGet() == total) {
+                        listener.onPokestopsCarregados(listaFinal);
                     }
                 });
             }
+        }).addOnFailureListener(e -> Log.e("PGO", "Erro na busca: " + e.getMessage()));
+    }
 
-        });
+    // Metodo auxiliar apenas para limpar o getPokestops
+    private void processarBancoDeDados(Pokestop pokestop) {
+        Cursor c = BancoDadosSingleton.getInstance().buscar("pokestop",
+                new String[]{"disponivel"}, "idPokestop = '" + pokestop.getID() + "'", "");
+
+        if (c.getCount() > 0 && c.moveToNext()) {
+            pokestop.setDisponivel(c.getInt(c.getColumnIndex("disponivel")) != 0);
+        } else {
+            ContentValues v = new ContentValues();
+            v.put("idPokestop", pokestop.getID());
+            v.put("latitude", pokestop.getlat());
+            v.put("longitude", pokestop.getlongi());
+            v.put("disponivel", true);
+            BancoDadosSingleton.getInstance().inserir("Pokestop", v);
+            pokestop.setDisponivel(true);
+        }
+        c.close();
+    }
+
+    // Recuperar imagem do local usando sdk places
+    private void getPlaceImage(Pokestop pokestop, List<PhotoMetadata> photoMetadatas, Runnable onFinish) {
+        if (photoMetadatas == null || photoMetadatas.isEmpty()) {
+            Log.d("FOTO", "Sem foto para: " + pokestop.getNome());
+            onFinish.run();
+            return;
+        }
+
+        PlacesClient placesClient = Places.createClient(MyApp.getAppContext());
+        FetchPhotoRequest photoRequest = FetchPhotoRequest.builder(photoMetadatas.get(0))
+                .setMaxWidth(500)
+                .setMaxHeight(300)
+                .build();
+
+        placesClient.fetchPhoto(photoRequest)
+                .addOnSuccessListener(response -> {
+                    pokestop.setFoto(response.getBitmap());
+                    onFinish.run();
+                })
+                .addOnFailureListener(e -> {
+                    Log.e("FOTO", "Erro ao baixar foto: " + e.getMessage());
+                    onFinish.run();
+                });
     }
 
     public Aparecimento[] getAparecimentos(){

--- a/app/src/main/java/teste/lucasvegi/pokemongooffline/Util/NearbySearch.java
+++ b/app/src/main/java/teste/lucasvegi/pokemongooffline/Util/NearbySearch.java
@@ -1,30 +1,35 @@
 package teste.lucasvegi.pokemongooffline.Util;
 
-import com.google.maps.GeoApiContext;
-import com.google.maps.PlacesApi;
-import com.google.maps.errors.ApiException;
-import com.google.maps.model.LatLng;
-import com.google.maps.model.PlacesSearchResponse;
-import com.google.maps.model.RankBy;
-
-import java.io.IOException;
+import com.google.android.gms.tasks.Task;
+import com.google.android.libraries.places.api.Places;
+import com.google.android.libraries.places.api.model.CircularBounds;
+import com.google.android.libraries.places.api.model.Place;
+import com.google.android.libraries.places.api.net.SearchNearbyRequest;
+import com.google.android.libraries.places.api.net.SearchNearbyResponse;
+import com.google.android.libraries.places.api.net.PlacesClient;
+import com.google.android.gms.maps.model.LatLng;
+import java.util.Arrays;
+import java.util.List;
 
 public class NearbySearch {
+    public static final List<Place.Field> FIELDS = Arrays.asList(
+            Place.Field.ID,
+            Place.Field.NAME,
+            Place.Field.LAT_LNG,
+            Place.Field.PHOTO_METADATAS
+    );
 
-    public static PlacesSearchResponse run( LatLng latlng) {
-        PlacesSearchResponse request = new PlacesSearchResponse();
-        GeoApiContext context = new GeoApiContext.Builder()
-                .apiKey("AIzaSyD_82FN8rMIJzMrZyx1l7xZbpW1SYN5pdU")
+    public static Task<SearchNearbyResponse> run(LatLng latLng) {
+        PlacesClient placesClient = Places.createClient(MyApp.getAppContext());
+
+        // Configuração do raio (300m) e ranking (POPULARITY)
+        CircularBounds circle = CircularBounds.newInstance(latLng, 300.0);
+
+        SearchNearbyRequest request = SearchNearbyRequest.builder(circle, FIELDS)
+                .setRankPreference(SearchNearbyRequest.RankPreference.POPULARITY)
+                .setMaxResultCount(15)
                 .build();
-        try {
-            request = PlacesApi.nearbySearchQuery(context, latlng)
-                    .rankby(RankBy.PROMINENCE)
-                    .radius(300)
-                    .await();
-            return request;
-        } catch (ApiException | IOException | InterruptedException e) {
-            e.printStackTrace();
-        }
-        return request;
+
+        return placesClient.searchNearby(request);
     }
 }

--- a/local.properties
+++ b/local.properties
@@ -4,5 +4,5 @@
 # Location of the SDK. This is only used by Gradle.
 # For customization when using a Version Control System, please read the
 # header note.
-#Sat Dec 12 14:21:41 BRT 2020
-sdk.dir=/root/Android/Sdk
+#Mon Mar 30 19:04:30 BRT 2026
+sdk.dir=C\:\\Android\\Sdk


### PR DESCRIPTION
Este PR realiza a atualização do Google Places SDK para a versão nativa mais recente (4.0.0), substituindo a lógica de consultas HTTP manuais por requisições tipadas e assíncronas. A refatoração foca na modernização da busca de Pokestops e na melhoria da arquitetura do código, aumentando a separação de responsabilidades.

Principais alterações:
- minSdkVersion: Atualizado para 24 (Android 7.0) para garantir compatibilidade com as bibliotecas modernas do Google Play Services e suporte nativo a recursos do Java 8+.
- Refatoração da Lógica de Busca (Nearby Search), onde houve a substituição do antigo PlacesApi.nearbySearchQuery pelo método placesClient.searchNearby().
- Uso do AoCarregarPokestopsListener para gerenciar o fluxo de dados entre a Controladora e a UI, evitando travamentos na thread principal e garantindo que os marcadores só sejam plotados quando os dados (incluindo fotos) estiverem prontos.